### PR TITLE
added account linking/email existence check function

### DIFF
--- a/src/lib/firebase/authentication/accountLinking.ts
+++ b/src/lib/firebase/authentication/accountLinking.ts
@@ -1,0 +1,28 @@
+import { db, auth } from '../firebaseConfig';
+import { getAuth, linkWithPopup, GoogleAuthProvider } from "firebase/auth";
+
+// Example:
+// 1. Existing Email/PWD account: (abc@gmail.com)
+// 2. An user wants to link a new sign-in google account (fgh@gmail.com)
+async function linkingAccount(): Promise<void> {
+    const auth = getAuth();
+    const user = auth.currentUser;
+
+    if (user) {
+        // User is signed in
+        const provider = new GoogleAuthProvider();
+        try {
+            await linkWithPopup(user, provider);
+            console.log("Accounts successfully linked");
+        } catch (error) {
+            console.log("Error occured while linking your account", error);
+        }
+    } else {
+        // No user is signed in.
+        alert("Sign-in needed");
+        // redirect to the login page
+        window.location.href = 'route/to/login';
+    }
+}
+
+export { linkingAccount };

--- a/src/lib/firebase/authentication/googleAuthentication.ts
+++ b/src/lib/firebase/authentication/googleAuthentication.ts
@@ -1,5 +1,4 @@
 import { auth } from '../firebaseConfig';
-import { FirebaseError } from 'firebase/app';
 import { signInWithPopup, signOut, GoogleAuthProvider } from 'firebase/auth';
 
 async function verifyGoogleToken(googleAccessToken: string | undefined): Promise<boolean> {
@@ -31,10 +30,8 @@ async function signInWithGoogle(): Promise<void> {
         } else {
             console.log("Please sign in again");
         }
-    } catch (error: unknown) {
-        if ((error as FirebaseError).code === 'auth/account-exists-with-different-credential') {
-            console.log("Already existing email address");
-        }
+    } catch (error) {
+        console.log("Unexpected error while signing in");
     };
 };
 

--- a/src/lib/firebase/util/userVerification.ts
+++ b/src/lib/firebase/util/userVerification.ts
@@ -1,0 +1,17 @@
+import { db } from '../firebaseConfig';
+import { collection, query, where, getDocs } from "firebase/firestore";
+
+async function checkEmailExists(email: string): Promise<boolean> {
+    const ref = collection(db, "users");
+    const q = query(ref, where("email", "==", email));
+    const querySnapshot = await getDocs(q);
+    if (!querySnapshot.empty) {
+        console.log("Email already exists in the database");
+        return true;
+    } else {
+        console.log("Email does not exist. You can register or sign-in with this email");
+        return false;
+    }
+}
+
+export { checkEmailExists };


### PR DESCRIPTION
Tasks Completed:
- added a function to link a google account to an existing email/pwd account
- added a function to check if the entered email already exists in the database (use for signing up process) 

p.s.
I guess I had a misunderstanding regarding account linking and authentication. I am sorry for any confusion caused. 
Based on the potential scenarios, I have implemented the code as follows: 
1. A user with an existing email/pwd account (abc@gmail.com) on the web tries to sign in (or sign up) with a google account using the same email address (abc@gmail.com).
       - the accounts are automatically linked according to the firebase auth setting.
2.  A user with an existing google account (def@gmail.com) on the web tries to sign up using an email/pwd account method with the same address (def@gmail.com).
       - this may be prevented if the entered email is checked during the sign-up process.
3. A user with an existing email/pwd account (abc@gmail.com) on the web wants to link a google account (xyz@gmail.com). 
       - account linking is only applicable in this case
       - it is not allowed to link an existing Google account to a new Google account.
