### PR TITLE
hotfix(security): update Next.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "firebase": "^12.2.1",
         "moment": "^2.30.1",
-        "next": "^14.2.34",
+        "next": "^14.2.35",
         "nodemailer": "^7.0.5",
         "radix-ui": "^1.4.3",
         "react-google-button": "^0.8.0",
@@ -3076,9 +3076,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.34",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.34.tgz",
-      "integrity": "sha512-iuGW/UM+EZbn2dm+aLx+avo1rVap+ASoFr7oLpTBVW2G2DqhD5l8Fme9IsLZ6TTsp0ozVSFswidiHK1NGNO+pg==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -8586,12 +8586,12 @@
       }
     },
     "node_modules/next": {
-      "version": "14.2.34",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.34.tgz",
-      "integrity": "sha512-s7mRraWlkEVRLjHHdu5khn0bSnmUh+U+YtigBc+t2Ge7jJHFIVBZna+W9Jcx7b04HhM7eJWrNJ2A+sQs9gJ3eg==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.34",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "firebase": "^12.2.1",
     "moment": "^2.30.1",
-    "next": "^14.2.34",
+    "next": "^14.2.35",
     "nodemailer": "^7.0.5",
     "radix-ui": "^1.4.3",
     "react-google-button": "^0.8.0",


### PR DESCRIPTION
- Patched Next.js version for [React vulnerability](https://nextjs.org/blog/security-update-2025-12-11) was updated from 14.2.34 to 14.2.35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js to the latest patch version for improved stability and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->