### PR TITLE
fix incorrect references to "surveyAccessList" subcollections

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -31,8 +31,8 @@ service cloud.firestore {
     }
 
     function isOnSurveyAccessList(surveyId) {
-      let data = get(/databases/$(database)/documents/surveys/$(surveyId)/surveyAccessList/surveyAccessList).data;
-      return data != null && data.keys().hasAny([request.auth.token.studentId]);
+      let data = get(/databases/$(database)/documents/students/$(request.auth.token.studentId)/surveyAccessList/surveyAccessList).data;
+      return data != null && data.keys().hasAny([surveyId]);
     }
 
     match /students/{studentId} {

--- a/functions/src/firestore/syncAdminData.ts
+++ b/functions/src/firestore/syncAdminData.ts
@@ -67,7 +67,6 @@ export const onSurveyDocDeleted = onDocumentDeleted('/surveys/{surveyId}', async
   const surveyId = event.params.surveyId;
   await Promise.all([
     adminDb.recursiveDelete(adminDb.collection(Collection.SURVEYS).doc(surveyId).collection(Collection.ASSIGNMENTS)),
-    adminDb.recursiveDelete(adminDb.collection(Collection.SURVEYS).doc(surveyId).collection(Collection.SURVEY_ACCESS_LIST)),
     updateAdminDataOnDocDeleted(
       adminDb.collection(Collection.ADMIN_DATA).doc(Document.SURVEYS).collection(Collection.SURVEYS),
       surveyId
@@ -76,11 +75,14 @@ export const onSurveyDocDeleted = onDocumentDeleted('/surveys/{surveyId}', async
 });
 
 export const onStudentDocCreated = onDocumentCreated('/students/{studentId}', async (event) =>
-  await updateAdminDataOnDocCreated(
-    adminDb.collection(Collection.ADMIN_DATA).doc(Document.STUDENTS).collection(Collection.STUDENTS),
-    event.params.studentId,
-    event.data?.data()
-  )
+  await Promise.all([
+    updateAdminDataOnDocCreated(
+      adminDb.collection(Collection.ADMIN_DATA).doc(Document.STUDENTS).collection(Collection.STUDENTS),
+      event.params.studentId,
+      event.data?.data()
+    ),
+    adminDb.collection(Collection.STUDENTS).doc(event.params.studentId).collection(Collection.SURVEY_ACCESS_LIST).doc(Document.SURVEY_ACCESS_LIST).create({})
+  ])
 );
 
 export const onStudentDocUpdated = onDocumentUpdated('/students/{studentId}', async (event) =>
@@ -92,8 +94,11 @@ export const onStudentDocUpdated = onDocumentUpdated('/students/{studentId}', as
 );
 
 export const onStudentDocDeleted = onDocumentDeleted('/students/{studentId}', async (event) =>
-  await updateAdminDataOnDocDeleted(
-    adminDb.collection(Collection.ADMIN_DATA).doc(Document.STUDENTS).collection(Collection.STUDENTS),
-    event.params.studentId
-  )
+  await Promise.all([
+    updateAdminDataOnDocDeleted(
+      adminDb.collection(Collection.ADMIN_DATA).doc(Document.STUDENTS).collection(Collection.STUDENTS),
+      event.params.studentId
+    ),
+    adminDb.collection(Collection.STUDENTS).doc(event.params.studentId).collection(Collection.SURVEY_ACCESS_LIST).doc(Document.SURVEY_ACCESS_LIST).delete()
+  ])
 );


### PR DESCRIPTION
- Fixed usage of "surveyAccessList" documents
  - Access list documents were not being created, which was causing errors when Cloud Functions attempted to write to them
  - Access list documents are now deleted when the associated user is deleted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Survey deletion now properly removes all associated access data.

* **Improvements**
  * Restructured survey access management organization.
  * Optimized student creation and deletion operations for better performance through concurrent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->