### PR TITLE
bugfix(survey_assignments): fix query for getting whether student has an existing assignment for a survey

### DIFF
--- a/functions/src/firestore/responseManagement.ts
+++ b/functions/src/firestore/responseManagement.ts
@@ -56,7 +56,7 @@ const addResponsesToFirestore = async (responses: GoogleFormResponse[], transact
   });
 
   const existingAssignments = await Promise.all(
-    idResponses.map(response => transaction.get(adminDb.collection(Collection.SURVEYS).doc(response.surveyId).collection(Collection.ASSIGNMENTS).where('studentId', '==', response.studentId).where('surveyId', '==', response.surveyId).where('responseId', '==', null).limit(1)))
+    idResponses.map(response => transaction.get(adminDb.collection(Collection.SURVEYS).doc(response.surveyId).collection(Collection.ASSIGNMENTS).where('studentId', '==', response.studentId).where('responseId', '==', null).limit(1)))
   );
   idResponses.forEach((response, index) => {
     existingAssignments[index].empty ? transaction.set(surveysCollection.doc(response.surveyId).collection(Collection.ASSIGNMENTS).doc(uuid()), {


### PR DESCRIPTION
- When performing this query, there was a "where" clause filtering on the "surveyId" field
  - This field exists only in the Firestore document's path, not the document contents, so the query was guaranteed to always return 0 results
  - Since no assignment was found, the assignments were never closed, but the responses were still added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a redundant filter condition from assignment queries to improve query efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->