### PR TITLE
bugfix(auth): properly handle rollback during account creation process

### DIFF
--- a/functions/src/auth.ts
+++ b/functions/src/auth.ts
@@ -61,23 +61,46 @@ export const createStudent = onCall(async (req) => {
     return nextStudentId;
   });
 
-  try {
-    const student: Student = { ...studentDto, id: String(studentId) };
-    const decodedToken = req.auth.token as unknown as StudentDecodedIdTokenWithCustomClaims
-    await Promise.all([
+  const student: Student = { id: String(studentId), ...studentDto };
+  const decodedToken = req.auth.token as unknown as StudentDecodedIdTokenWithCustomClaims;
+  const oldUser = await adminAuth.getUser(req.auth.uid);
+  const [userResponse, claimsResponse] = await Promise.allSettled([
+    adminAuth.updateUser(req.auth.uid, {
+      displayName: getFullName(student.name),
+      email: student.email ?? undefined,
+      phoneNumber: student.phone
+    }),
+    adminAuth.setCustomUserClaims(req.auth.uid, {
+      role: decodedToken.role,
+      studentId: student.id
+    } satisfies StudentCustomClaims)
+  ])
+
+  const status = userResponse.status === "fulfilled" && claimsResponse.status === "fulfilled" ? 'fulfilled' : 'rejected';
+
+  if (status === "fulfilled") { return; }
+
+  const rollbackPromises: Promise<unknown>[] = [adminDb.collection(Collection.STUDENTS).doc(String(studentId)).delete()];
+  if (userResponse.status === "fulfilled") {
+    rollbackPromises.push(
       adminAuth.updateUser(req.auth.uid, {
-        displayName: getFullName(student.name),
-        email: student.email ?? undefined,
-        phoneNumber: student.phone
-      }),
+        displayName: oldUser.displayName,
+        email: oldUser.email,
+        phoneNumber: oldUser.phoneNumber
+      })
+    )
+  }
+  if (claimsResponse.status === "fulfilled") {
+    rollbackPromises.push(
       adminAuth.setCustomUserClaims(req.auth.uid, {
         role: decodedToken.role,
-        studentId: student.id,
-      } satisfies StudentCustomClaims)
-    ])
-  } catch {
-    adminDb.collection(Collection.STUDENTS).doc(String(studentId)).delete();
+        studentId: decodedToken.studentId
+      })
+    )
   }
+
+  await Promise.all(rollbackPromises);
+  throw new HttpsError("internal", "Unable to complete student creation process");
 });
 
 export const handleEmailChange = onCall(async (req) => {


### PR DESCRIPTION
- Previously, if account creation failed, only the creation of the student Firestore document was rolled back
- This resulted in a state where the user in Firebase Auth would have a "studentId" set in their custom claims, which corresponded to no Firestore document
  - When a user logged in, this resulted in an error page instead of an account creation screen with no way to navigate to account creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced student account creation to automatically revert changes if the process fails, ensuring data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->