### PR TITLE
bugfix(users): hide IncompleteProfileMessage from ADMIN users since it's not applicable

### DIFF
--- a/src/features/profile/IncompleteProfileMessage.tsx
+++ b/src/features/profile/IncompleteProfileMessage.tsx
@@ -4,13 +4,15 @@ import useStudents from "@/data/hooks/useStudents/useStudents";
 import styles from "./IncompleteProfileMessage.module.css";
 import { FaX } from "react-icons/fa6";
 import { useState } from "react";
+import useAuth from "../auth/authN/components/useAuth";
 
 export default function IncompleteProfileMessage() {
   const [isVisible, setIsVisible] = useState<boolean>(true);
 
+  const auth = useAuth();
   const { students } = useStudents();
 
-  if (!students[0]) {
+  if (auth.token?.claims.role !== 'STUDENT' || !students[0]) {
     return <></>;
   }
 


### PR DESCRIPTION
- ADMIN users should not be able to see the IncompleteProfileMessage since they do not have profiles for themselves
  - Because of this bug, they were seeing the message when the student user that happened to be first in the list of fetched students had an incomplete profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication validation in profile display to ensure the incomplete profile message only appears for authorized student users with valid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->