### PR TITLE
bugfix(deployment): remove minor & patch versions of Node.js from package.json files

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,7 +2,7 @@ name: Deploy to Firebase Hosting on merge
 on:
   push:
     branches:
-      - main
+      - bugfix/node-deployment-error
 jobs:
   deploy_next_app:
     name: Deploy Next.js App to Firebase Hosting

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,7 +2,7 @@ name: Deploy to Firebase Hosting on merge
 on:
   push:
     branches:
-      - bugfix/node-deployment-error
+      - main
 jobs:
   deploy_next_app:
     name: Deploy Next.js App to Firebase Hosting

--- a/apps-script/package.json
+++ b/apps-script/package.json
@@ -5,7 +5,7 @@
     "deploy": "npm run build && clasp push --force"
   },
   "engines": {
-    "node": "24.14.1",
+    "node": "24",
     "npm": "11.12.1"
   },
   "devDependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22.22.0",
+    "node": "22",
     "npm": "11.12.1"
   },
   "main": "lib/functions/src/index.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "deploy": "npm run build && firebase deploy"
   },
   "engines": {
-    "node": "24.14.1",
+    "node": "24",
     "npm": "11.12.1"
   },
   "workspaces": [


### PR DESCRIPTION
- Firebase deployment failed because package.json's `"engines.node"` field did not exactly match `"20"`, `"22"`, or `"24"` since it included the minor and patch version, so I removed them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime compatibility requirements across configuration files to use broader version ranges instead of pinned exact versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->