### PR TITLE
feat(auth): add validation to username/password auth provider

### DIFF
--- a/functions/src/auth.ts
+++ b/functions/src/auth.ts
@@ -235,7 +235,7 @@ export const signUpWithUsernamePassword = onRequest({ cors: true }, async (req, 
     await adminDb.runTransaction(async (transaction: Transaction) => {
       const usernameDoc = await transaction.get(adminDb.collection(Collection.USERNAMES).doc(username));
       if (usernameDoc.exists) {
-        throw new Error("Username already taken");
+        throw new HttpsError("already-exists", "Username already taken");
       }
       transaction.set(adminDb.collection(Collection.USERNAMES).doc(username), { uid });
       transaction.set(adminDb.collection(Collection.USERS).doc(uid), { username, password: pwHash });

--- a/src/app/LoginPage.tsx
+++ b/src/app/LoginPage.tsx
@@ -42,7 +42,7 @@ export default function LoginPage() {
       if (isEmail(email)) {
         await signUpUser(email, password);
       } else {
-        await signUpWithUsernamePassword(email, password);
+        await signUpWithUsernamePassword(email.trim().toLowerCase(), password);
       }
     } catch (error: any) {
       setError("Failed to sign up. Please try again later.");

--- a/src/app/LoginPage.tsx
+++ b/src/app/LoginPage.tsx
@@ -45,6 +45,10 @@ export default function LoginPage() {
         await signUpWithUsernamePassword(email.trim().toLowerCase(), password);
       }
     } catch (error: any) {
+      if (error.message.startsWith("Username") || error.message.startsWith("Password")) {
+        setError(error.message);
+        return;
+      }
       setError("Failed to sign up. Please try again later.");
     }
   };

--- a/src/features/auth/authN/emailPasswordAuthN.ts
+++ b/src/features/auth/authN/emailPasswordAuthN.ts
@@ -87,7 +87,7 @@ export async function resetPassword(oobCode: string, newPassword: string): Promi
   }
 }
 
-async function checkPasswordValidity(password: string): Promise<void> {
+export async function checkPasswordValidity(password: string): Promise<void> {
   // Skip validation when not in prod environment since Firebase Auth Emulator does not support password validation
   if (process.env.NODE_ENV !== "production") { return; }
   let validation;

--- a/src/features/auth/authN/usernamePasswordAuthN.ts
+++ b/src/features/auth/authN/usernamePasswordAuthN.ts
@@ -3,7 +3,23 @@ import { getFunctionsURL } from "@/config/utils";
 import { signInWithCustomToken } from "firebase/auth";
 import { checkPasswordValidity } from "./emailPasswordAuthN";
 
+function checkUsernameValidity(username: string) {
+  username = username.trim().toLowerCase();
+  if (username.length < 3) {
+    throw Error("Username must be at least 3 characters.");
+  } else if (username.length > 32) {
+    throw Error("Username must be at most 32 characters.");
+  } else if (!/^[a-zA-Z0-9.\-_]+$/.test(username)) {
+    throw Error("Username must only contain alphanumeric characters, hyphens, underscores, and periods.");
+  } else if (!/^[a-zA-Z].*$/.test(username)) {
+    throw Error("Username must start with a letter.");
+  } else if (!/^.*[a-zA-Z0-9]$/.test(username)) {
+    throw Error("Username must end with a letter or number.");
+  }
+}
+
 export async function signUpWithUsernamePassword(username: string, password: string) {
+  checkUsernameValidity(username);
   await checkPasswordValidity(password);
   const res = await fetch(getFunctionsURL('signUpWithUsernamePassword'), {
     method: "POST",

--- a/src/features/auth/authN/usernamePasswordAuthN.ts
+++ b/src/features/auth/authN/usernamePasswordAuthN.ts
@@ -1,8 +1,10 @@
 import { auth } from "@/config/firebaseConfig";
 import { getFunctionsURL } from "@/config/utils";
 import { signInWithCustomToken } from "firebase/auth";
+import { checkPasswordValidity } from "./emailPasswordAuthN";
 
 export async function signUpWithUsernamePassword(username: string, password: string) {
+  await checkPasswordValidity(password);
   const res = await fetch(getFunctionsURL('signUpWithUsernamePassword'), {
     method: "POST",
     body: JSON.stringify({


### PR DESCRIPTION
- Added password validation for users signing up using the custom username/password auth provider
  - Previously, password validation was only occurring for users signing up using Firebase's built-in email/password auth provider
- Added username validation for users signing up using the custom username/password auth provider
  - Username must be between 3-32 characters, inclusive
  - Username must contain only alphanumeric characters, hyphens, underscores, and periods
  - Username must start with a letter
  - Username must end with a letter or number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client-side validation for username signup, enforcing length (3–32 characters) and character restrictions.
  * Enhanced password validation during signup flow.

* **Bug Fixes**
  * Improved error messages during signup to provide specific feedback for username and password issues.
  * Email input now automatically normalized (trimmed and lowercased) during signup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->