### PR TITLE
feat(surveys): make survey titles & descriptions editable

### DIFF
--- a/apps-script/src/globals.d.ts
+++ b/apps-script/src/globals.d.ts
@@ -20,6 +20,8 @@ declare global {
   var getUpdatedSurveyTitlesAndDescriptions: (surveyIds: string[], startTime: string) => Pick<SurveyID, 'id' | 'name' | 'description'>[];
   var deleteSurvey: (surveyId: string) => void;
   var deleteSurveys: (surveyIds: string[]) => void;
+  var updateSurveyTitle: (surveyId: string, newTitle: string) => void;
+  var updateSurveyDescription: (surveyId: string, newDescription: string) => void;
 }
 
 export { };

--- a/apps-script/src/surveys.ts
+++ b/apps-script/src/surveys.ts
@@ -15,7 +15,7 @@ function createNewSurvey(title: string, description: string): SurveyID {
 
   try {
     DriveApp.getFileById(survey.getId()).setSharing(DriveApp.Access.DOMAIN_WITH_LINK, DriveApp.Permission.EDIT);
-  } catch (error) {}
+  } catch (error) { }
 
   return {
     id: survey.getId(),
@@ -51,7 +51,7 @@ function addExistingSurvey(surveyId: string) {
 
   try {
     DriveApp.getFileById(survey.getId()).setSharing(DriveApp.Access.DOMAIN_WITH_LINK, DriveApp.Permission.EDIT);
-  } catch (error) {}
+  } catch (error) { }
 
   return {
     survey: {
@@ -151,5 +151,17 @@ function deleteSurveys(surveyIds: string[]) {
   surveyIds.forEach((surveyId) => deleteSurvey(surveyId));
 }
 globalThis.deleteSurveys = deleteSurveys;
+
+function updateSurveyTitle(surveyId: string, newTitle: string) {
+  const survey = FormApp.openById(surveyId);
+  survey.setTitle(newTitle);
+}
+globalThis.updateSurveyTitle = updateSurveyTitle;
+
+function updateSurveyDescription(surveyId: string, newDescription: string) {
+  const survey = FormApp.openById(surveyId);
+  survey.setDescription(newDescription);
+}
+globalThis.updateSurveyDescription = updateSurveyDescription;
 
 export { };

--- a/src/app/surveys/[surveyId]/SurveyPage.module.css
+++ b/src/app/surveys/[surveyId]/SurveyPage.module.css
@@ -10,6 +10,10 @@
   padding: 2.5%;
 }
 
+.pointer {
+  cursor: pointer;
+}
+
 .header {
   display: flex;
   flex-direction: column;

--- a/src/app/surveys/[surveyId]/SurveyPage.module.css
+++ b/src/app/surveys/[surveyId]/SurveyPage.module.css
@@ -19,6 +19,8 @@
 }
 
 .surveyTitle {
+  display: flex;
+  flex-direction: row;
   font-family: "Poppins", sans-serif;
   color: #d0d12a;
   font-size: 40px;
@@ -27,6 +29,8 @@
 }
 
 .surveyDescription {
+  display: flex;
+  flex-direction: row;
   font-family: "Poppins", sans-serif;
   color: #dedeb2;
   font-size: 20px;

--- a/src/app/surveys/[surveyId]/SurveyPage.tsx
+++ b/src/app/surveys/[surveyId]/SurveyPage.tsx
@@ -283,12 +283,12 @@ export default function SurveyPage(props: SurveyPageProps) {
                   value={newTitle}
                   onChange={(e) => setNewTitle(e.target.value)}
                 />
-                <MdCheck onClick={() => setIsEditingTitle((prev) => !prev)} />
+                <MdCheck onClick={() => setIsEditingTitle(false)} />
               </>
             ) : (
               <>
                 <div>{survey.name}</div>
-                <MdEdit onClick={() => setIsEditingTitle((prev) => !prev)} />
+                <MdEdit onClick={() => setIsEditingTitle(true)} />
               </>
             )}
           </h1>
@@ -301,14 +301,14 @@ export default function SurveyPage(props: SurveyPageProps) {
                   onChange={(e) => setNewDescription(e.target.value)}
                 />
                 <MdCheck
-                  onClick={() => setIsEditingDescription((prev) => !prev)}
+                  onClick={() => setIsEditingDescription(false)}
                 />
               </>
             ) : (
               <>
                 <div>{survey.description}</div>
                 <MdEdit
-                  onClick={() => setIsEditingDescription((prev) => !prev)}
+                  onClick={() => setIsEditingDescription(true)}
                 />
               </>
             )}

--- a/src/app/surveys/[surveyId]/SurveyPage.tsx
+++ b/src/app/surveys/[surveyId]/SurveyPage.tsx
@@ -34,7 +34,10 @@ import { MdCheck, MdEdit } from "react-icons/md";
 import TextField from "@/features/accountManagement/components/TextField";
 import { updateSurvey } from "@/data/firestore/surveys";
 import { appsScriptCloudFunctions } from "../../../../functions/src/googleAppsScript";
-import { updateSurveyDescription, updateSurveyTitle } from "@/data/apps-script/calls";
+import {
+  updateSurveyDescription,
+  updateSurveyTitle,
+} from "@/data/apps-script/calls";
 
 interface SurveyPageProps {
   surveyId: string;
@@ -286,31 +289,41 @@ export default function SurveyPage(props: SurveyPageProps) {
                   value={newTitle}
                   onChange={(e) => setNewTitle(e.target.value)}
                 />
-                <MdCheck onClick={async () => {
-                  await Promise.all([
-                    updateSurvey(survey.id, { name: newTitle }),
-                    updateSurveyTitle(survey.id, newTitle),
-                  ])
-                  setIsEditingTitle(false);
-                }} />
+                <MdCheck
+                  className={styles.pointer}
+                  onClick={async () => {
+                    await Promise.all([
+                      updateSurvey(survey.id, { name: newTitle }),
+                      updateSurveyTitle(survey.id, newTitle),
+                    ]);
+                    setIsEditingTitle(false);
+                  }}
+                />
               </>
             ) : (
               <>
                 <div>{survey.name}</div>
-                <MdEdit onClick={async () => setIsEditingTitle(true)} />
+                <MdEdit
+                  className={styles.pointer}
+                  onClick={async () => setIsEditingTitle(true)}
+                />
               </>
             )}
           </h1>
           <h2 className={styles.surveyDescription}>
             {isEditingDescription ? (
               <>
-                <textarea value={newDescription} onChange={(e) => setNewDescription(e.target.value)} />
+                <textarea
+                  value={newDescription}
+                  onChange={(e) => setNewDescription(e.target.value)}
+                />
                 <MdCheck
+                  className={styles.pointer}
                   onClick={async () => {
                     await Promise.all([
                       updateSurvey(survey.id, { description: newDescription }),
                       updateSurveyDescription(survey.id, newDescription),
-                    ])
+                    ]);
                     setIsEditingDescription(false);
                   }}
                 />
@@ -319,6 +332,7 @@ export default function SurveyPage(props: SurveyPageProps) {
               <>
                 <div>{survey.description}</div>
                 <MdEdit
+                  className={styles.pointer}
                   onClick={() => setIsEditingDescription(true)}
                 />
               </>

--- a/src/app/surveys/[surveyId]/SurveyPage.tsx
+++ b/src/app/surveys/[surveyId]/SurveyPage.tsx
@@ -304,11 +304,7 @@ export default function SurveyPage(props: SurveyPageProps) {
           <h2 className={styles.surveyDescription}>
             {isEditingDescription ? (
               <>
-                <TextField
-                  label="Survey Description"
-                  value={newDescription}
-                  onChange={(e) => setNewDescription(e.target.value)}
-                />
+                <textarea value={newDescription} onChange={(e) => setNewDescription(e.target.value)} />
                 <MdCheck
                   onClick={async () => {
                     await Promise.all([

--- a/src/app/surveys/[surveyId]/SurveyPage.tsx
+++ b/src/app/surveys/[surveyId]/SurveyPage.tsx
@@ -33,6 +33,7 @@ import BlankBackgroundPage from "@/components/layout/pages/BlankBackgroundPage";
 import { MdCheck, MdEdit } from "react-icons/md";
 import TextField from "@/features/accountManagement/components/TextField";
 import { updateSurvey } from "@/data/firestore/surveys";
+import { appsScriptCloudFunctions } from "../../../../functions/src/googleAppsScript";
 
 interface SurveyPageProps {
   surveyId: string;
@@ -292,10 +293,7 @@ export default function SurveyPage(props: SurveyPageProps) {
             ) : (
               <>
                 <div>{survey.name}</div>
-                <MdEdit onClick={async () => {
-                  await updateSurvey(survey.id, { name: newTitle });
-                  setIsEditingTitle(true);
-                }} />
+                <MdEdit onClick={async () => setIsEditingTitle(true)} />
               </>
             )}
           </h1>
@@ -308,7 +306,10 @@ export default function SurveyPage(props: SurveyPageProps) {
                   onChange={(e) => setNewDescription(e.target.value)}
                 />
                 <MdCheck
-                  onClick={() => setIsEditingDescription(false)}
+                  onClick={async () => {
+                    await updateSurvey(survey.id, { description: newDescription});
+                    setIsEditingDescription(false);
+                  }}
                 />
               </>
             ) : (

--- a/src/app/surveys/[surveyId]/SurveyPage.tsx
+++ b/src/app/surveys/[surveyId]/SurveyPage.tsx
@@ -11,7 +11,7 @@ import {
   SurveyResponseStudentIdID,
   SurveyResponseUnidentifiedID,
 } from "@/types/survey-types";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import styles from "./SurveyPage.module.css";
 import LoadingPage from "@/app/loading";
 import Link from "next/link";
@@ -30,6 +30,8 @@ import SurveyActivationSwitch from "@/features/surveyManagement/components/Surve
 import ErrorPage from "@/app/error";
 import MenuIcon from "@/components/ui/MenuIcon";
 import BlankBackgroundPage from "@/components/layout/pages/BlankBackgroundPage";
+import { MdCheck, MdEdit } from "react-icons/md";
+import TextField from "@/features/accountManagement/components/TextField";
 
 interface SurveyPageProps {
   surveyId: string;
@@ -52,6 +54,19 @@ export default function SurveyPage(props: SurveyPageProps) {
 
   const [selectedPendingAssignmentIds, setSelectedPendingAssignmentIds] =
     useState<string[]>([]);
+  const [isEditingTitle, setIsEditingTitle] = useState<boolean>(false);
+  const [newTitle, setNewTitle] = useState<string>(survey?.name || "");
+  const [isEditingDescription, setIsEditingDescription] =
+    useState<boolean>(false);
+  const [newDescription, setNewDescription] = useState<string>(
+    survey?.description || "",
+  );
+
+  useEffect(() => {
+    setNewTitle(survey?.name || "");
+    setNewDescription(survey?.description || "");
+  }, [survey]);
+
   const {
     assignments,
     setAssignments,
@@ -65,13 +80,13 @@ export default function SurveyPage(props: SurveyPageProps) {
     assignments.forEach((assignment) =>
       isPendingAssignmentID(assignment)
         ? pendingAssignments.push(assignment)
-        : surveyResponses.push(assignment)
+        : surveyResponses.push(assignment),
     );
     pendingAssignments = pendingAssignments.sort((a, b) =>
-      a.assignedAt.localeCompare(b.assignedAt)
+      a.assignedAt.localeCompare(b.assignedAt),
     );
     surveyResponses = surveyResponses.sort((a, b) =>
-      b.submittedAt.localeCompare(a.submittedAt)
+      b.submittedAt.localeCompare(a.submittedAt),
     );
     return { pendingAssignments, surveyResponses };
   }, [assignments]);
@@ -90,7 +105,7 @@ export default function SurveyPage(props: SurveyPageProps) {
       isSurveyResponseStudentIdID(assignment)
     ) {
       const student = students.find(
-        (student) => student.id === assignment.studentId
+        (student) => student.id === assignment.studentId,
       );
       return student ? getFullName(student.name) : "N/A";
     }
@@ -103,7 +118,7 @@ export default function SurveyPage(props: SurveyPageProps) {
       isPendingAssignmentID(assignment)
     ) {
       const student = students.find(
-        (student) => student.id === assignment.studentId
+        (student) => student.id === assignment.studentId,
       );
       return student && student.email ? student.email : "N/A";
     } else if (isSurveyResponseStudentEmailID(assignment)) {
@@ -118,7 +133,7 @@ export default function SurveyPage(props: SurveyPageProps) {
       getValue: getStudentNameFromAssignment,
       sortFunc: (a, b) =>
         getStudentNameFromAssignment(a).localeCompare(
-          getStudentNameFromAssignment(b)
+          getStudentNameFromAssignment(b),
         ),
     },
     {
@@ -145,7 +160,7 @@ export default function SurveyPage(props: SurveyPageProps) {
       sortFunc: (a, b) => {
         if (isSurveyResponseStudentIdID(a) && isSurveyResponseStudentIdID(b)) {
           return getStudentNameFromAssignment(a).localeCompare(
-            getStudentNameFromAssignment(b)
+            getStudentNameFromAssignment(b),
           );
         } else if (isSurveyResponseStudentIdID(a)) {
           return -1;
@@ -226,7 +241,7 @@ export default function SurveyPage(props: SurveyPageProps) {
                       } satisfies SurveyResponseUnidentifiedID);
                 }
                 return a;
-              })
+              }),
             )
           }
         />
@@ -260,8 +275,44 @@ export default function SurveyPage(props: SurveyPageProps) {
     <BlankBackgroundPage>
       <div className={styles.container}>
         <div className={styles.header}>
-          <h1 className={styles.surveyTitle}>{survey.name}</h1>
-          <h2 className={styles.surveyDescription}>{survey.description}</h2>
+          <h1 className={styles.surveyTitle}>
+            {isEditingTitle ? (
+              <>
+                <TextField
+                  label="Survey Title"
+                  value={newTitle}
+                  onChange={(e) => setNewTitle(e.target.value)}
+                />
+                <MdCheck onClick={() => setIsEditingTitle((prev) => !prev)} />
+              </>
+            ) : (
+              <>
+                <div>{survey.name}</div>
+                <MdEdit onClick={() => setIsEditingTitle((prev) => !prev)} />
+              </>
+            )}
+          </h1>
+          <h2 className={styles.surveyDescription}>
+            {isEditingDescription ? (
+              <>
+                <TextField
+                  label="Survey Description"
+                  value={newDescription}
+                  onChange={(e) => setNewDescription(e.target.value)}
+                />
+                <MdCheck
+                  onClick={() => setIsEditingDescription((prev) => !prev)}
+                />
+              </>
+            ) : (
+              <>
+                <div>{survey.description}</div>
+                <MdEdit
+                  onClick={() => setIsEditingDescription((prev) => !prev)}
+                />
+              </>
+            )}
+          </h2>
           <div className={styles.surveyOptionMenu}>
             <Link
               href={`https://docs.google.com/forms/d/${survey.id}/edit`}
@@ -291,7 +342,7 @@ export default function SurveyPage(props: SurveyPageProps) {
                 <SendSurveyReminderEmailModal
                   survey={survey}
                   assignments={pendingAssignments.filter((assignment) =>
-                    selectedPendingAssignmentIds.includes(assignment.id)
+                    selectedPendingAssignmentIds.includes(assignment.id),
                   )}
                 />
               )}

--- a/src/app/surveys/[surveyId]/SurveyPage.tsx
+++ b/src/app/surveys/[surveyId]/SurveyPage.tsx
@@ -34,6 +34,7 @@ import { MdCheck, MdEdit } from "react-icons/md";
 import TextField from "@/features/accountManagement/components/TextField";
 import { updateSurvey } from "@/data/firestore/surveys";
 import { appsScriptCloudFunctions } from "../../../../functions/src/googleAppsScript";
+import { updateSurveyDescription, updateSurveyTitle } from "@/data/apps-script/calls";
 
 interface SurveyPageProps {
   surveyId: string;
@@ -286,7 +287,10 @@ export default function SurveyPage(props: SurveyPageProps) {
                   onChange={(e) => setNewTitle(e.target.value)}
                 />
                 <MdCheck onClick={async () => {
-                  await updateSurvey(survey.id, { name: newTitle });
+                  await Promise.all([
+                    updateSurvey(survey.id, { name: newTitle }),
+                    updateSurveyTitle(survey.id, newTitle),
+                  ])
                   setIsEditingTitle(false);
                 }} />
               </>
@@ -307,7 +311,10 @@ export default function SurveyPage(props: SurveyPageProps) {
                 />
                 <MdCheck
                   onClick={async () => {
-                    await updateSurvey(survey.id, { description: newDescription});
+                    await Promise.all([
+                      updateSurvey(survey.id, { description: newDescription }),
+                      updateSurveyDescription(survey.id, newDescription),
+                    ])
                     setIsEditingDescription(false);
                   }}
                 />

--- a/src/app/surveys/[surveyId]/SurveyPage.tsx
+++ b/src/app/surveys/[surveyId]/SurveyPage.tsx
@@ -32,6 +32,7 @@ import MenuIcon from "@/components/ui/MenuIcon";
 import BlankBackgroundPage from "@/components/layout/pages/BlankBackgroundPage";
 import { MdCheck, MdEdit } from "react-icons/md";
 import TextField from "@/features/accountManagement/components/TextField";
+import { updateSurvey } from "@/data/firestore/surveys";
 
 interface SurveyPageProps {
   surveyId: string;
@@ -283,12 +284,18 @@ export default function SurveyPage(props: SurveyPageProps) {
                   value={newTitle}
                   onChange={(e) => setNewTitle(e.target.value)}
                 />
-                <MdCheck onClick={() => setIsEditingTitle(false)} />
+                <MdCheck onClick={async () => {
+                  await updateSurvey(survey.id, { name: newTitle });
+                  setIsEditingTitle(false);
+                }} />
               </>
             ) : (
               <>
                 <div>{survey.name}</div>
-                <MdEdit onClick={() => setIsEditingTitle(true)} />
+                <MdEdit onClick={async () => {
+                  await updateSurvey(survey.id, { name: newTitle });
+                  setIsEditingTitle(true);
+                }} />
               </>
             )}
           </h1>

--- a/src/data/apps-script/calls.ts
+++ b/src/data/apps-script/calls.ts
@@ -27,3 +27,5 @@ export async function deactivateSurvey(surveyId: string): Promise<void> { return
 export async function deleteSurvey(surveyId: string): Promise<void> { return await callAppsScript('deleteSurvey', [surveyId]); }
 export async function deleteSurveys(surveyIds: string[]): Promise<void> { return await callAppsScript('deleteSurveys', [surveyIds]); }
 export async function getUpdatedSurveyTitlesAndDescriptions(surveyIds: string[], startTime: string): Promise<Pick<SurveyID, 'id' | 'name' | 'description'>[]> { return await callAppsScript('getUpdatedSurveyTitlesAndDescriptions', [surveyIds, startTime]); }
+export async function updateSurveyTitle(surveyId: string, newTitle: string): Promise<void> { return await callAppsScript('updateSurveyTitle', [surveyId, newTitle]); }
+export async function updateSurveyDescription(surveyId: string, newDescription: string): Promise<void> { return await callAppsScript('updateSurveyDescription', [surveyId, newDescription]); }

--- a/src/features/accountManagement/components/TextField.tsx
+++ b/src/features/accountManagement/components/TextField.tsx
@@ -9,7 +9,7 @@ interface TextFieldProps {
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   required?: boolean;
   disabled?: boolean;
-  icon: JSX.Element;
+  icon?: JSX.Element;
   maxLength?: number;
 }
 
@@ -28,7 +28,7 @@ export default function TextField(props: TextFieldProps) {
     <div className={styles.inputGroup}>
       <Label label={label} required={required} />
       <div className={`${styles.inputField} ${disabled ? styles.disabledInputField : ""}`}>
-        {cloneElement(icon, { className: styles.inputIcon })}
+        {icon && cloneElement(icon, { className: styles.inputIcon })}
         <input
           className={styles.inputText}
           placeholder={placeholder}


### PR DESCRIPTION
- Made survey titles & descriptions editable from the SurveyPage
  - Editing title or descriptions updates info in both Firestore & Google Forms
  - Wrote new Apps Script functions for updating a Google Form's title or description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Survey titles and descriptions can now be edited inline on survey pages with instant saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->