### PR TITLE
bugfix(surveys): add "View Survey" column to surveys table to allow navigation to SurveyPage when survey title is empty

### DIFF
--- a/src/app/surveys/SurveysPage.tsx
+++ b/src/app/surveys/SurveysPage.tsx
@@ -29,9 +29,7 @@ export default function SurveysPage() {
     {
       name: "Name",
       getValue: (survey: SurveyID) => (
-        <Link href={`/surveys/${survey.id}`}>
-          <p className={styles.linkText}>{survey.name}</p>
-        </Link>
+        <p>{survey.name}</p>
       ),
       sortFunc: (a, b) => a.name.localeCompare(b.name),
     },
@@ -52,7 +50,7 @@ export default function SurveysPage() {
       ),
     },
     {
-      name: "View Survey",
+      name: "View Google Form",
       getValue: (survey: SurveyID) => (
         <Link href={survey.responderUri} target="_blank">
           <FaEye className={styles.linkIcon} size={20} />
@@ -77,6 +75,14 @@ export default function SurveysPage() {
       ),
       sortFunc: (a, b) => (a.isActive === b.isActive ? 0 : a.isActive ? -1 : 1),
     },
+    {
+      name: "View Survey",
+      getValue: (survey: SurveyID) => (
+        <Link href={`/surveys/${survey.id}`}>
+          <p className={styles.linkText}>View Survey</p>
+        </Link>
+      ),
+    }
   ];
 
   const filterConditions: FilterCondition<SurveyID>[] = [


### PR DESCRIPTION
- Google Apps Script has a known issue where form titles are sometimes empty (#82)
- Due to this, in the surveys table, users are unable to navigate to the SurveyPage for surveys that have had this issue since the survey's title was the part that was hyperlinked
- To fix this, I added a "View Survey" column that links to the SurveyPage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "View Survey" column to the survey table for accessing the internal survey page.

* **Style**
  * Survey names are now displayed as plain text instead of functioning as navigation links.
  * "View" column clarified to "View Google Form" to distinguish from the new internal survey view option.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hack4Impact-UMD/swaliga-foundation/pull/107)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->