### PR TITLE
bugfix(students): fix bug where admin email overwrites student email when editing student account

### DIFF
--- a/src/features/accountManagement/components/EditAccountForm.tsx
+++ b/src/features/accountManagement/components/EditAccountForm.tsx
@@ -602,7 +602,7 @@ export default function EditAccountForm(props: EditAccountFormProps) {
       <div className={styles.row}>
         <TextField
           label="Email"
-          value={auth.user?.email || ""}
+          value={mode === "EDIT" ? (student.email ?? "") : ""}
           placeholder="No email was used to login to this account."
           disabled
           icon={<FaEnvelope />}

--- a/src/features/accountManagement/components/EditAccountForm.tsx
+++ b/src/features/accountManagement/components/EditAccountForm.tsx
@@ -602,7 +602,7 @@ export default function EditAccountForm(props: EditAccountFormProps) {
       <div className={styles.row}>
         <TextField
           label="Email"
-          value={mode === "EDIT" ? (student.email ?? "") : ""}
+          value={mode === "EDIT" ? (student.email ?? "") : (auth.user?.email ?? "")}
           placeholder="No email was used to login to this account."
           disabled
           icon={<FaEnvelope />}

--- a/src/features/accountManagement/components/EditAccountForm.tsx
+++ b/src/features/accountManagement/components/EditAccountForm.tsx
@@ -455,7 +455,7 @@ export default function EditAccountForm(props: EditAccountFormProps) {
           lastName,
         },
         gender: gender === "Other" ? genderOtherText : gender,
-        ...(auth.user?.email ? { email: auth.user.email } : {}),
+        ...(mode === "CREATE" && auth.user?.email ? { email: auth.user.email } : {}),
         ...(phone ? { phone: toE164Phone(phone) } : {}),
         uid: auth.user!.uid,
         role: "STUDENT",


### PR DESCRIPTION
- When an admin user edited a student's account, the admin's email would overwrite the student's existing email because the email field was being pulled from the logged in user, not the student's Firestore document
  - Changed the email field to get the value from the student's Firestore document
  - Modified submit function to only set the email field on student creation, not student update
- Will run email backfill job once this PR is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed email field behavior in account form: the authenticated user's email is now only automatically included when creating a new account, not when editing existing accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->