### PR TITLE
bugfix(students): don't change student uid when another user is editing a student's account

### DIFF
--- a/src/features/accountManagement/components/EditAccountForm.tsx
+++ b/src/features/accountManagement/components/EditAccountForm.tsx
@@ -448,6 +448,7 @@ export default function EditAccountForm(props: EditAccountFormProps) {
 
     try {
       if (!auth.user) throw new Error("No authenticated user found.");
+      // @ts-expect-error - UID should not be updated when admin users are editing a student's account
       const studentDTO: Omit<Student, "id"> = {
         name: {
           firstName,
@@ -457,7 +458,7 @@ export default function EditAccountForm(props: EditAccountFormProps) {
         gender: gender === "Other" ? genderOtherText : gender,
         ...(mode === "CREATE" && auth.user?.email ? { email: auth.user.email } : {}),
         ...(phone ? { phone: toE164Phone(phone) } : {}),
-        uid: auth.user!.uid,
+        ...(mode === "CREATE" ? { uid: auth.user!.uid } : {}),
         role: "STUDENT",
         dateOfBirth,
         ...(joinedSwaligaDate ? { joinedSwaligaDate } : {}),


### PR DESCRIPTION
- Same issue as in #108, but students' uids were also being overwritten with the admin's uid
  - Caused my original backfill to fail, so going to figure out another way to backfill students' emails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where student account identifiers could be incorrectly modified when editing existing accounts. The system now properly preserves account identifiers during updates while correctly setting them only when creating new accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->